### PR TITLE
chore: update release tags to latest versions

### DIFF
--- a/jazzy/repo.yaml
+++ b/jazzy/repo.yaml
@@ -6,11 +6,11 @@ repositories:
   lib_mem_dmabuf:
     type: git
     url: https://github.com/qualcomm-qrb-ros/lib_mem_dmabuf
-    version: 1.1.1-jazzy
+    version: 1.1.2
   libqrc:
     type: git
     url: https://github.com/qualcomm-qrb-ros/libqrc
-    version: 1.1.1-jazzy
+    version: 1.1.2
   qrb_ros_amr_service:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_amr_service
@@ -26,7 +26,7 @@ repositories:
   qrb_ros_camera:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_camera
-    version: 2.0.1-jazzy
+    version: 2.0.2
   qrb_ros_follow_path_service:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_follow_path_service
@@ -38,15 +38,15 @@ repositories:
   qrb_ros_interfaces:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_interfaces
-    version: 1.0.0
+    version: 2.0.0
   qrb_ros_nn_inference:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_nn_inference
-    version: v1.2.0
+    version: 1.3.0
   qrb_ros_robot_base:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_robot_base
-    version: 1.2.3
+    version: 1.2.4
   qrb_ros_samples:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_samples.git
@@ -54,7 +54,7 @@ repositories:
   qrb_ros_system_monitor:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_system_monitor
-    version: 1.1.1-jazzy
+    version: 1.1.2
   qrb_ros_tensor_process:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_tensor_process
@@ -62,8 +62,20 @@ repositories:
   qrb_ros_transport:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_transport
-    version: 1.3.1-jazzy
+    version: 1.3.2
   qrb_ros_video:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_video.git
     version: v0.1.7
+  ocr_service:
+    type: git
+    url: https://github.com/qualcomm-qrb-ros/ocr_service
+    version: 1.0.1
+  qrb_ros_color_space_convert:
+    type: git
+    url: https://github.com/qualcomm-qrb-ros/qrb_ros_color_space_convert
+    version: 1.0.1
+  qrb_ros_audio_service:
+    type: git
+    url: https://github.com/qualcomm-qrb-ros/qrb_ros_audio_service
+    version: 1.1.0


### PR DESCRIPTION
Update release tags:

- `lib_mem_dmabuf`: `1.1.1-jazzy` → `1.1.2`
- `libqrc`: `1.1.1-jazzy` → `1.1.2`
- `qrb_ros_camera`: `2.0.1-jazzy` → `2.0.2`
- `qrb_ros_interfaces`: `1.0.0` → `2.0.0`
- `qrb_ros_nn_inference`: `v1.2.0` → `1.3.0`
- `qrb_ros_robot_base`: `1.2.3` → `1.2.4`
- `qrb_ros_system_monitor`: `1.1.1-jazzy` → `1.1.2`
- `qrb_ros_transport`: `1.3.1-jazzy` → `1.3.2`
- `ocr_service`: (new) → 1.0.1
- `qrb_ros_color_space_convert`: (new) → 1.0.1
- ` qrb_ros_audio_service`: (new) → 1.1.0