### PR TITLE
chore: update develop branch versions to main

### DIFF
--- a/jazzy/repo.yaml
+++ b/jazzy/repo.yaml
@@ -17,7 +17,7 @@ repositories:
     version: main
   qrb_ros_audio_service:
     type: git
-    url: https://github.com/qualcomm-qrb-ros/qrb_ros_audio_service.git
+    url: https://github.com/qualcomm-qrb-ros/qrb_ros_audio_service
     version: main
   qrb_ros_battery:
     type: git
@@ -33,7 +33,7 @@ repositories:
     version: main
   qrb_ros_color_space_convert:
     type: git
-    url: https://github.com/qualcomm-qrb-ros/qrb_ros_color_space_convert.git
+    url: https://github.com/qualcomm-qrb-ros/qrb_ros_color_space_convert
     version: main
   qrb_ros_follow_path_service:
     type: git
@@ -74,4 +74,8 @@ repositories:
   qrb_ros_video:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_video.git
+    version: main
+  ocr_service:
+    type: git
+    url: https://github.com/qualcomm-qrb-ros/ocr_service
     version: main


### PR DESCRIPTION
Update develop branch versions to track `main`:

- `ocr_service`: **(new)** `main`
- `qrb_ros_color_space_convert`: **(new)** `main`
- `qrb_ros_audio_service`: **(new)** `main`
- `qrb_ros_calibrator`: **(new)** `main`
- `qrb_ros_simulation`: **(new)** `main`