### PR TITLE
ci: migrate to qrb ros upload-artifact action and upgrade checkout

### DIFF
--- a/.github/workflows/distro_build.yaml
+++ b/.github/workflows/distro_build.yaml
@@ -130,7 +130,6 @@ jobs:
             -DBUILD_TESTING=OFF
 
       - name: Stage build artifacts for publishing
-        continue-on-error: true
         run: |
           build_dir=./uploads
           mkdir -p $build_dir
@@ -138,7 +137,7 @@ jobs:
           tar -cvf ${build_dir}/${{ github.event.repository.name }}-${MACHINE}-${DISTRO}-${QCOM_SELECTED_BSP}-artifacts.tar --transform "s|^${WORKSPACE}/||" -C ${WORKSPACE} install
 
       - name: Upload artifacts to S3 bucket
-        uses: qualcomm-linux/upload-private-artifact-action@aws-v4
+        uses: qualcomm-qrb-ros/qrb_ros_gh_actions/.github/actions/upload-artifact@main
         with:
           path: ./uploads
           destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/

--- a/.github/workflows/distro_build_ubuntu.yml
+++ b/.github/workflows/distro_build_ubuntu.yml
@@ -24,13 +24,9 @@ jobs:
           sudo add-apt-repository ppa:ubuntu-qcom-iot/qirp
           sudo apt update -y && sudo apt upgrade -y
           sudo apt install -y tree python3-vcstool wget unzip
-          # Install awscli
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install
 
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           path: ${{ env.ROS_SRC }}/${{ github.event.repository.name }}
@@ -65,7 +61,6 @@ jobs:
           colcon build
 
       - name: Stage build artifacts for publishing
-        continue-on-error: true
         run: |
           build_dir=./uploads
           mkdir -p $build_dir
@@ -73,7 +68,7 @@ jobs:
           tar -cvf "${build_dir}/${{ github.event.repository.name }}-ubuntu-artifacts.tar" --transform "s|^${ROS_WS}/||" -C "${ROS_WS}" install
 
       - name: Upload artifacts to S3 bucket
-        uses: qualcomm-linux/upload-private-artifact-action@aws-v4
+        uses: qualcomm-qrb-ros/qrb_ros_gh_actions/.github/actions/upload-artifact@main
         with:
           path: ./uploads
           destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/


### PR DESCRIPTION
## Description
- Replace qualcomm-linux/upload-private-artifact-action@aws-v4 with qrb_ros_gh_actions upload-artifact composite action (both workflows)
- Remove manual AWS CLI installation; now handled by the composite action
- Upgrade actions/checkout from v4 to v6.0.2 (Node.js 24)

## Related Issue
none

## Type of Change
<!-- Please check the one that applies to this PR using "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): CI update

## Scope of Change
<!-- Please check the one that applies to this PR using "x" -->
- [ ] Repository configuration update
- [ ] Distribution or repo.yaml update
- [ ] Package version change
- [ ] Qualcomm dependency update (qrb-ros-dep)
- [x] CI/CD or build system changes
- [ ] Other (please describe):