### PR TITLE
feat: update managed project releases for 0.5.0

### DIFF
--- a/jazzy/repo.yaml
+++ b/jazzy/repo.yaml
@@ -2,11 +2,11 @@ repositories:
   dmabuf_transport:
     type: git
     url: https://github.com/qualcomm-qrb-ros/dmabuf_transport
-    version: 1.1.0
+    version: release/1.1.1
   lib_mem_dmabuf:
     type: git
     url: https://github.com/qualcomm-qrb-ros/lib_mem_dmabuf
-    version: 1.1.2
+    version: release/1.1.3
   libqrc:
     type: git
     url: https://github.com/qualcomm-qrb-ros/libqrc
@@ -54,7 +54,7 @@ repositories:
   qrb_ros_system_monitor:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_system_monitor
-    version: 1.1.2
+    version: release/1.1.3
   qrb_ros_tensor_process:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_tensor_process
@@ -62,7 +62,7 @@ repositories:
   qrb_ros_transport:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_transport
-    version: 1.3.2
+    version: release/1.4.0
   qrb_ros_video:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_video.git
@@ -74,7 +74,7 @@ repositories:
   qrb_ros_color_space_convert:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_color_space_convert
-    version: 1.0.1
+    version: release/1.0.2
   qrb_ros_audio_service:
     type: git
     url: https://github.com/qualcomm-qrb-ros/qrb_ros_audio_service


### PR DESCRIPTION
Update managed project refs in `jazzy/repo.yaml` for qrb_ros_distro 0.5.0 validation.

Included projects:
- `lib_mem_dmabuf`: `release/1.1.3`
- `dmabuf_transport`: `release/1.1.1`
- `qrb_ros_transport`: `release/1.4.0`
- `qrb_ros_system_monitor`: `release/1.1.3`
- `qrb_ros_color_space_convert`: `release/1.0.2`

Signed-off-by: Peng Wang <penwang@qti.qualcomm.com>